### PR TITLE
Fetch builders from indexer

### DIFF
--- a/packages/nextjs/hooks/useCohortAddBuilderEvents.ts
+++ b/packages/nextjs/hooks/useCohortAddBuilderEvents.ts
@@ -1,0 +1,25 @@
+import { gql, useQuery } from "urql";
+import contracts from "~~/generated/hardhat_contracts";
+
+const BuildersQuery = gql`
+  query Builders($cohortAddress: String!) {
+    cohortBuilders(where: { cohortContractAddress: $cohortAddress }, orderBy: "timestamp", orderDirection: "desc") {
+      amount
+      ens
+      id
+      timestamp
+    }
+  }
+`;
+
+export const useAddBuilderEvents = () => {
+  const [{ data: addBuilderEventsData, fetching: isLoading }] = useQuery({
+    query: BuildersQuery,
+    variables: {
+      cohortAddress: contracts[10][0].contracts.SandGardenStreams.address,
+    },
+  });
+
+  const data = addBuilderEventsData?.cohortBuilders || [];
+  return { data, isLoading };
+};

--- a/packages/nextjs/hooks/useCohortAddBuilderEvents.ts
+++ b/packages/nextjs/hooks/useCohortAddBuilderEvents.ts
@@ -4,10 +4,7 @@ import contracts from "~~/generated/hardhat_contracts";
 const BuildersQuery = gql`
   query Builders($cohortAddress: String!) {
     cohortBuilders(where: { cohortContractAddress: $cohortAddress }, orderBy: "timestamp", orderDirection: "desc") {
-      amount
-      ens
       id
-      timestamp
     }
   }
 `;

--- a/packages/nextjs/hooks/useCohortWithdrawEvents.ts
+++ b/packages/nextjs/hooks/useCohortWithdrawEvents.ts
@@ -8,7 +8,6 @@ const WithdrawalsQuery = gql`
       builder
       amount
       timestamp
-      builder
       id
     }
   }

--- a/packages/nextjs/pages/members.tsx
+++ b/packages/nextjs/pages/members.tsx
@@ -3,9 +3,9 @@ import { ethers } from "ethers";
 import type { NextPage } from "next";
 import { StreamContractInfo } from "~~/components/StreamContractInfo";
 import { Address, EtherInput } from "~~/components/scaffold-eth";
-import { useScaffoldContractRead, useScaffoldContractWrite, useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
+import { useScaffoldContractRead, useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
+import { useAddBuilderEvents } from "~~/hooks/useCohortAddBuilderEvents";
 import { useCohortWithdrawEvents } from "~~/hooks/useCohortWithdrawEvents";
-import scaffoldConfig from "~~/scaffold.config";
 
 const Members: NextPage = () => {
   const [reason, setReason] = useState("");
@@ -29,15 +29,11 @@ const Members: NextPage = () => {
 
   const { data: allWithdrawEvents, isLoading: isWithdrawEventsLoading } = useCohortWithdrawEvents();
 
-  const { data: addBuilderEvents, isLoading: isLoadingBuilderEvents } = useScaffoldEventHistory({
-    contractName: "SandGardenStreams",
-    eventName: "AddBuilder",
-    fromBlock: scaffoldConfig.contracts.SandGardenStreams.fromBlock,
-  });
+  const { data: addBuilderEvents, isLoading: isLoadingBuilderEvents } = useAddBuilderEvents();
 
   useEffect(() => {
     if (addBuilderEvents && addBuilderEvents.length > 0) {
-      const fetchedBuilderList = addBuilderEvents.map((event: any) => event.args.to);
+      const fetchedBuilderList = addBuilderEvents.map((event: any) => event.id.split("-")[0]);
       setBuilderList(fetchedBuilderList);
     }
   }, [addBuilderEvents]);

--- a/packages/nextjs/pages/members.tsx
+++ b/packages/nextjs/pages/members.tsx
@@ -44,8 +44,6 @@ const Members: NextPage = () => {
     }
   }, [selectedAddress, allWithdrawEvents]);
 
-  const sortedBuilders = allBuildersData && [...allBuildersData].reverse();
-
   return (
     <>
       <div className="max-w-3xl px-4 py-8">
@@ -62,7 +60,7 @@ const Members: NextPage = () => {
             </div>
           ) : (
             <div className="flex flex-col gap-6">
-              {sortedBuilders?.map(builderData => {
+              {allBuildersData?.map(builderData => {
                 if (builderData.cap.isZero()) return;
                 const cap = ethers.utils.formatEther(builderData.cap || 0);
                 const unlocked = ethers.utils.formatEther(builderData.unlockedAmount || 0);


### PR DESCRIPTION
Following #6 steps:
- Created a hook to fetch all `addBuilder` events from Ponder.
- Switched data fetching in `/members` from `useScaffoldEventHistory` hook to the new `useAddBuilderEvents` hook.

In `cohortBuilders` query from Ponder indexer we didn't have a `builder` field (not sure if I had to create it somehow or fields are autoindexed). We have the builder info into the `id` field, concatenated with the contract address, so just did a `split` to grab it.

Closes #5 